### PR TITLE
feat: remove `@synhaptein` fork from falcor-http-datasource

### DIFF
--- a/lib/falcor-http-ws-datasource.js
+++ b/lib/falcor-http-ws-datasource.js
@@ -1,5 +1,5 @@
 import SocketIoClient from 'socket.io-client';
-import FalcorHttpDataSource from '@synhaptein/falcor-http-datasource';
+import FalcorHttpDataSource from 'falcor-http-datasource';
 import Uuid from 'uuid';
 import DelayedFunction from './delayed-function';
 import Q from 'q';
@@ -51,11 +51,6 @@ class FalcorHttpPullWebSocketPushDataSource extends FalcorHttpDataSource {
 
     config.headers[config.tabIdLabel || 'X-TabId'] = tabId;
 
-    if (!config.bearerToken && config.headers['Authorization']) {
-      let tokens = config.headers.Authorization.split(' ');
-      config.bearerToken = tokens[1];
-    }
-
     let socket = null;
     if (pushUrl && pushUrl.length > 0) {
       let wsUrlPath = pushUrl.match(/(ws+:\/\/[A-Za-z0-9\-\.]*:?[0-9]*)(\/?.*)/);
@@ -75,9 +70,9 @@ class FalcorHttpPullWebSocketPushDataSource extends FalcorHttpDataSource {
     this.requestWatcher = new DelayedFunction(200); // Delay maxium between 2 falcor requests
   }
 
-  _readBearerTokenFromDynamicHeaders() {
-    if (this.config.dynamicHeaders) {
-      let tokens = this.config.dynamicHeaders ? this.config.dynamicHeaders()['Authorization'].split(' ') : null;
+  _readBearerTokenFromHeaders() {
+    if (!this.config.bearerToken && this.config.headers.Authorization) {
+      let tokens = this.config.headers.Authorization.split(' ');
       this.config.bearerToken = tokens[1];
     }
 
@@ -96,7 +91,7 @@ class FalcorHttpPullWebSocketPushDataSource extends FalcorHttpDataSource {
       this.socket = new SocketIoClient(this.pushUrl, this.config);
 
       this.socket.on('connect', () => {
-        this.socket.emit('authorization', {bearerToken: this._readBearerTokenFromDynamicHeaders(), tabId: this.tabId});
+        this.socket.emit('authorization', {bearerToken: this._readBearerTokenFromHeaders(), tabId: this.tabId});
       });
 
       if (this.callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor-http-ws-datasource",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "Falcor HTTP and WebSocket datasource",
   "homepage": "",
   "author": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ""
   ],
   "dependencies": {
-    "@synhaptein/falcor-http-datasource": "0.1.6",
+    "falcor-http-datasource": "0.1.3",
     "q": "1.4.1",
     "socket.io-client": "1.5.0",
     "uuid": "2.0.1"


### PR DESCRIPTION
This was used to have dynamic headers, but this could be handled by
client directly. If you want dynamic headers, you could have an object
with dynamic properties.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty for more details